### PR TITLE
Create sample kubernetes deployment

### DIFF
--- a/contrib/k8s-deploy.yaml
+++ b/contrib/k8s-deploy.yaml
@@ -1,0 +1,123 @@
+# An alternative to the kubernetes job also submitted in the contrib/
+# directory
+#
+# To install:
+# - kubectl create namespace FOO
+# - kubectl -n FOO create -f (this file)
+#
+# To check logs:
+# - kubectl -n FOO logs -l app=withings-sync
+#
+#
+# Because the app is running without STDIN, it will not pause to wait
+# for you to enter the oauth token.  Instead it will throw an error
+#   EOFError: EOF when reading a line
+# and continue to sleep.  To set up for the first time, run something
+# like this manually, and enter the oauth token provided after you
+# follow the link given:
+#
+# - kubectl -n FOO exec -ti $( kubectl -n FOO get pods | awk '$3=="Running" {print $1; exit}' ) -- withings-sync
+#
+#
+#
+
+
+---
+
+# Secret for credentials.  By defining this as stringData:
+# instead of data: we can enter details here in plain text and
+# it gets base64 encoded when added to the system.
+#
+# Leave unused variables defined, but empty ""
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: credentials
+type: Opaque
+stringData:
+  # NOT base64 
+  GARMIN_PASSWORD: "someone@example.com"
+  GARMIN_USERNAME: "password-goes-here"
+  TRAINERROAD_PASSWORD: ""
+  TRAINERROAD_USERNAME: ""
+
+---
+
+# PVC for storing Withings OAuth tokens.  Different
+# storage methods have different minimum sizes.
+#
+# If you don't have a default storage class, you must
+# specify it
+#
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: withings-oauth-cache
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 10Mi
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: withings-sync
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: withings-sync
+  template:
+    metadata:
+      labels:
+        app: withings-sync
+    spec:
+      # container image is only build for amd64 at the moment
+      nodeSelector:
+        kubernetes.io/arch: amd64
+
+      containers:
+      - name: withings-sync
+        image: docker.io/stv0g/withings-sync
+        imagePullPolicy: IfNotPresent
+
+        # override $HOME to put our oauth file in a known place
+        env:
+        - name: HOME
+          value: /data
+
+        # read usernames/passwords from the secret we defined
+        envFrom:
+        - secretRef:
+            name: credentials
+
+        volumeMounts:
+        - mountPath: /data
+          name: oauth-cache
+
+        # run every 15 minutes, synched to clock time
+        command:
+        - sh
+        - -c
+        - while true; do date; withings-sync; echo; sleep $( echo "900 - ( $( date +%s ) % 900 )" | bc ); done
+
+      # Never run this container as root
+      securityContext:
+        fsGroup: 1234
+        runAsGroup: 1234
+        runAsUser: 1234
+        runAsNonRoot: True
+
+      volumes:
+      - name: oauth-cache
+        persistentVolumeClaim:
+          claimName: withings-oauth-cache
+
+

--- a/contrib/k8s-deploy.yaml
+++ b/contrib/k8s-deploy.yaml
@@ -107,7 +107,7 @@ spec:
         command:
         - sh
         - -c
-        - while true; do date; withings-sync; echo; sleep $( echo "900 - ( $( date +%s ) % 900 )" | bc ); done
+        - while true; do date; withings-sync; echo; sleep $( echo "3600 - ( $( date +%s ) % 3600 )" | bc ); done
 
       # Never run this container as root
       securityContext:

--- a/contrib/k8s-deploy.yaml
+++ b/contrib/k8s-deploy.yaml
@@ -80,7 +80,7 @@ spec:
       labels:
         app: withings-sync
     spec:
-      # container image is only build for amd64 at the moment
+      # container image is only built for amd64 at the moment
       nodeSelector:
         kubernetes.io/arch: amd64
 

--- a/contrib/k8s-deploy.yaml
+++ b/contrib/k8s-deploy.yaml
@@ -57,7 +57,8 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  storageClassName: longhorn
+  # uncomment, and define if needed
+  # storageClassName: class
   resources:
     requests:
       storage: 10Mi


### PR DESCRIPTION
The contrib/ directory already has an example of using a kubernetes job to run the sync.  I've re-written it as a deployment and fixed a few minor issues (e.g. permitting to run as root by default, fully qualified container name, etc) along the way.

