### PR TITLE
Fix Garmin SSO Authentication error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     install_requires=[
         'lxml',
         'requests'
+        'cloudscraper'
     ],
     entry_points={
         'console_scripts': [

--- a/withings_sync/garmin.py
+++ b/withings_sync/garmin.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 import urllib.request
 import urllib.error
 import urllib.parse
-import requests
+import cloudscraper
 import re
 import sys
 import json
@@ -42,7 +42,7 @@ class GarminConnect(object):
     # From https://github.com/cpfair/tapiriik
 
     def _get_session(self, record=None, email=None, password=None):
-        session = requests.Session()
+        session = cloudscraper.CloudScraper()
 
         # JSIG CAS, cool I guess.
         # Not quite OAuth though, so I'll continue to collect raw credentials.


### PR DESCRIPTION
Garmin Connect is behind Cloudflare nowadays.  This means that direct use of the requests library is not sufficient anymore to post data. 
The cloudscraper library takes care of this for us. 