### PR TITLE
Attempt to set credentials from secrets files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ optional arguments:
   --verbose, -v         Run verbosely
 ```
 
-### Providing crendtials via environment variables
+### Providing credentials via environment variables
 
 You can use the following environment variables for providing the Garmin and/or Trainerroad credentials:
 
@@ -57,6 +57,25 @@ You can use the following environment variables for providing the Garmin and/or 
 - `GARMIN_PASSWORD` 
 - `TRAINERROAD_USERNAME`
 - `TRAINERROAD_PASSWORD`
+
+### Providing credentials via secrets files
+
+You can also populate the following 'secrets' files to provide the Garmin and/or Trainerroad credentials:
+
+- `/run/secrets/garmin_username`
+- `/run/secrets/garmin_password`
+- `/run/secrets/trainerroad_username`
+- `/run/secrets/trainerroad_password`
+
+Secrets are useful in an orchestrated container context — see the [Docker Swarm](https://docs.docker.com/engine/swarm/secrets/) or [Rancher](https://rancher.com/docs/rancher/v1.6/en/cattle/secrets/) docs for more information on how to securely inject secrets into a container.
+
+### Order of priority for credentials
+
+In the case of credentials being available via multiple means (e.g. [environment variables](#providing-credentials-via-environment-variables) and [secrets files](#providing-credentials-via-secrets-files)), the order of resolution for determining which credentials to use is as follows, with later methods overriding credentials supplied by an earlier method:
+
+1. Read secrets file(s)
+2. Read environment variable(s)
+3. Use command invocation arugment(s)
 
 ### Obtaining Withings Authorization Code
 

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -68,7 +68,7 @@ def get_args():
                         default=GARMIN_USERNAME,
                         type=str,
                         metavar='GARMIN_USERNAME',
-                        help='username to login to Garmin Connect.')
+                        help='username to log in to Garmin Connect.')
     parser.add_argument('--garmin-password', '--gp',
                         default=GARMIN_PASSWORD,
                         type=str,

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -73,7 +73,7 @@ def get_args():
                         default=GARMIN_PASSWORD,
                         type=str,
                         metavar='GARMIN_PASSWORD',
-                        help='password to login to Garmin Connect.')
+                        help='password to log in to Garmin Connect.')
 
     parser.add_argument('--trainerroad-username', '--tu', 
                         default=TRAINERROAD_USERNAME,

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -84,7 +84,7 @@ def get_args():
                         default=TRAINERROAD_PASSWORD,
                         type=str,
                         metavar='TRAINERROAD_PASSWORD',
-                        help='password to login to TrainerRoad.')
+                        help='password to log in to TrainerRoad.')
 
     parser.add_argument('--fromdate', '-f',
                         type=date_parser,

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -12,6 +12,48 @@ from withings_sync.trainerroad import TrainerRoad
 from withings_sync.fit import FitEncoder_Weight
 
 
+try:
+	secret = open("/run/secrets/garmin_username")
+	GARMIN_USERNAME = secret.read()
+	secret.close()
+except Exception:
+	GARMIN_USERNAME = ''
+
+try:
+	secret = open("/run/secrets/garmin_password")
+	GARMIN_PASSWORD = secret.read()
+	secret.close()
+except Exception:
+	GARMIN_PASSWORD = ''
+
+if "GC_USERNAME" in os.environ:
+	GARMIN_USERNAME = os.getenv("GARMIN_USERNAME")
+
+if "GC_PASSWORD" in os.environ:
+	GARMIN_PASSWORD = os.getenv("GARMIN_PASSWORD")
+
+
+try:
+	secret = open("/run/secrets/trainerroad_username")
+	TRAINERROAD_USERNAME = secret.read()
+	secret.close()
+except Exception:
+	TRAINERROAD_USERNAME = ''
+
+try:
+	secret = open("/run/secrets/trainerroad_password")
+	TRAINERROAD_PASSWORD = secret.read()
+	secret.close()
+except Exception:
+	TRAINERROAD_PASSWORD = ''
+
+if "TR_USERNAME" in os.environ:
+	TRAINERROAD_USERNAME = os.getenv("TRAINERROAD_USERNAME")
+
+if "TR_PASSWORD" in os.environ:
+	TRAINERROAD_PASSWORD = os.getenv("TRAINERROAD_PASSWORD")
+
+
 def get_args():
     parser = argparse.ArgumentParser(
         description=('A tool for synchronisation of Withings '
@@ -23,26 +65,26 @@ def get_args():
         return datetime.strptime(s, '%Y-%m-%d')
 
     parser.add_argument('--garmin-username', '--gu',
-                        default=os.environ.get('GARMIN_USERNAME'),
+                        default=GARMIN_USERNAME,
                         type=str,
                         metavar='GARMIN_USERNAME',
-                        help='username to login Garmin Connect.')
+                        help='username to login to Garmin Connect.')
     parser.add_argument('--garmin-password', '--gp',
-                        default=os.environ.get('GARMIN_PASSWORD'),
+                        default=GARMIN_PASSWORD,
                         type=str,
                         metavar='GARMIN_PASSWORD',
-                        help='password to login Garmin Connect.')
+                        help='password to login to Garmin Connect.')
 
-    parser.add_argument('--trainerroad-username', '--tu',
-                        default=os.environ.get('TRAINERROAD_USERNAME'),
+    parser.add_argument('--trainerroad-username', '--tu', 
+                        default=TRAINERROAD_USERNAME,
                         type=str,
                         metavar='TRAINERROAD_USERNAME',
-                        help='username to login TrainerRoad.')
-    parser.add_argument('--trainerroad-password', '--tp',
-                        default=os.environ.get('TRAINERROAD_PASSWORD'),
+                        help='username to login to TrainerRoad.')
+    parser.add_argument('--trainerroad-password', '--tp', 
+                        default=TRAINERROAD_PASSWORD,
                         type=str,
                         metavar='TRAINERROAD_PASSWORD',
-                        help='username to login TrainerRoad.')
+                        help='password to login to TrainerRoad.')
 
     parser.add_argument('--fromdate', '-f',
                         type=date_parser,

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -79,7 +79,7 @@ def get_args():
                         default=TRAINERROAD_USERNAME,
                         type=str,
                         metavar='TRAINERROAD_USERNAME',
-                        help='username to login to TrainerRoad.')
+                        help='username to log in to TrainerRoad.')
     parser.add_argument('--trainerroad-password', '--tp', 
                         default=TRAINERROAD_PASSWORD,
                         type=str,


### PR DESCRIPTION
Hi, I'm using your code in [Rancher](https://rancher.com), and made the modification in this PR to grab the credentials from Rancher secrets rather than environment variables or directly. I thought you might find it useful to merge, though no offence if you don't want the cruft.

n.b. it looks as though the `contrib/k8s*` files now in the repo achieve the same goal for k8s for the st0vg container image. It would be better not to have to build my own image as I do now, but I don't think the k8s config works for Rancher.

The secrets files are:
  - `/run/secrets/garmin_username` — Garmin Connect username
  - `/run/secrets/garmin_password` — Garmin Connect password
  - `/run/secrets/trainerroad_username` — TrainerRoad username
  - `/run/secrets/trainerroad_password` — TrainerRoad password