### PR TITLE
Add possibility to save downloaded FIT data to file (reworked)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ pip install withings-sync
 
 ```
 usage: withings-sync [-h] [--garmin-username GARMIN_USERNAME] [--garmin-password GARMIN_PASSWORD] [--trainerroad-username TRAINERROAD_USERNAME] [--trainerroad-password TRAINERROAD_PASSWORD]
-                     [--fromdate DATE] [--todate DATE] [--no-upload] [--to-json] [--verbose]
+                     [--fromdate DATE] [--todate DATE] [--to-fit] [--to-json] [--output BASENAME] [--no-upload] [--verbose]
 
 A tool for synchronisation of Withings (ex. Nokia Health Body) to Garmin Connect and Trainer Road or to provide a json string.
 
@@ -47,8 +47,11 @@ optional arguments:
                         username to login TrainerRoad.
   --fromdate DATE, -f DATE
   --todate DATE, -t DATE
-  --no-upload           Won't upload to Garmin Connect and output binary-strings to stdout.
-  --to-json, -j         Won't upload to Garmin Connect and output json to stdout.
+  --to-fit, -F          Write output file in FIT format.
+  --to-json, -J         Write output file in JSON format.
+  --output BASENAME, -o BASENAME
+                        Write downloaded measurements to file.
+  --no-upload           Won't upload to Garmin Connect or TrainerRoad.
   --verbose, -v         Run verbosely
 ```
 


### PR DESCRIPTION
_This is an update of #42_

For backup purpose and to upload body measurements to platforms other than Garmin and TrainerRoad I would like to store the FIT or JSON data in a file. Because the original --no-upload mixes log messages and FIT or JSON data on stdout it is not possible to just redirect the output to a file. This patch adds --output to the list of arguments to specify a base filename where the FIT or JSON data is stored.

Attention: This patch changes the previous behavior of --no-upload which now doesn't print the FIT or JSON data to stdout.