### PR TITLE
Python Code Style changes (black & pylint) for sync.py

### DIFF
--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -17,13 +17,13 @@ from withings_sync.fit import FitEncoder_Weight
 try:
     with open("/run/secrets/garmin_username", encoding="utf-8") as secret:
         GARMIN_USERNAME = secret.read()
-except Exception:
+except OSError:
     GARMIN_USERNAME = ""
 
 try:
     with open("/run/secrets/garmin_password", encoding="utf-8") as secret:
         GARMIN_PASSWORD = secret.read()
-except Exception:
+except OSError:
     GARMIN_PASSWORD = ""
 
 if "GC_USERNAME" in os.environ:
@@ -36,13 +36,13 @@ if "GC_PASSWORD" in os.environ:
 try:
     with open("/run/secrets/trainerroad_username", encoding="utf-8") as secret:
         TRAINERROAD_USERNAME = secret.read()
-except Exception:
+except OSError:
     TRAINERROAD_USERNAME = ""
 
 try:
     with open("/run/secrets/trainerroad_password", encoding="utf-8") as secret:
         TRAINERROAD_PASSWORD = secret.read()
-except Exception:
+except OSError:
     TRAINERROAD_PASSWORD = ""
 
 if "TR_USERNAME" in os.environ:
@@ -275,7 +275,7 @@ def sync(
             try:
                 with open(filename, "wb") as fitfile:
                     fitfile.write(fit.getvalue())
-            except (OSError, IOError):
+            except OSError:
                 logging.error("Unable to open output file!")
         if to_json:
             filename = output + ".json"
@@ -283,7 +283,7 @@ def sync(
             try:
                 with open(filename, "w", encoding="utf-8") as jsonfile:
                     json.dump(json_data, jsonfile, indent=4)
-            except (OSError, IOError):
+            except OSError:
                 logging.error("Unable to open output file!")
 
     if no_upload:

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -271,7 +271,7 @@ def sync(
     if output is not None:
         if to_fit:
             filename = output + ".fit"
-            logging.info("Writing file to {}".format(filename))
+            logging.info("Writing file to %s.", filename)
             try:
                 with open(filename, "wb") as fitfile:
                     fitfile.write(fit.getvalue())
@@ -279,7 +279,7 @@ def sync(
                 logging.error("Unable to open output file!")
         if to_json:
             filename = output + ".json"
-            logging.info("Writing file to {}".format(filename))
+            logging.info("Writing file to %s.", filename)
             try:
                 with open(filename, "w") as jsonfile:
                     json.dump(json_data, jsonfile, indent=4)
@@ -293,14 +293,14 @@ def sync(
     # Upload to Trainer Road
     if trainerroad_username:
         logging.info("Trainerroad username set -- attempting to sync")
-        logging.info(" Last weight {}".format(last_weight))
-        logging.info(" Measured {}".format(last_dt))
+        logging.info(" Last weight %s.", last_weight)
+        logging.info(" Measured %s.", last_dt)
 
         tr = TrainerRoad(trainerroad_username, trainerroad_password)
         tr.connect()
 
-        logging.info(f"Current TrainerRoad weight: {tr.weight} kg ")
-        logging.info(f"Updating TrainerRoad weight to {last_weight} kg")
+        logging.info("Current TrainerRoad weight: %s kg.", tr.weight)
+        logging.info("Updating TrainerRoad weight to %s kg.", last_weight)
 
         tr.weight = round(last_weight, 1)
         tr.disconnect()

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -14,118 +14,144 @@ from withings_sync.fit import FitEncoder_Weight
 
 
 try:
-	secret = open("/run/secrets/garmin_username")
-	GARMIN_USERNAME = secret.read()
-	secret.close()
+    secret = open("/run/secrets/garmin_username")
+    GARMIN_USERNAME = secret.read()
+    secret.close()
 except Exception:
-	GARMIN_USERNAME = ''
+    GARMIN_USERNAME = ""
 
 try:
-	secret = open("/run/secrets/garmin_password")
-	GARMIN_PASSWORD = secret.read()
-	secret.close()
+    secret = open("/run/secrets/garmin_password")
+    GARMIN_PASSWORD = secret.read()
+    secret.close()
 except Exception:
-	GARMIN_PASSWORD = ''
+    GARMIN_PASSWORD = ""
 
 if "GC_USERNAME" in os.environ:
-	GARMIN_USERNAME = os.getenv("GARMIN_USERNAME")
+    GARMIN_USERNAME = os.getenv("GARMIN_USERNAME")
 
 if "GC_PASSWORD" in os.environ:
-	GARMIN_PASSWORD = os.getenv("GARMIN_PASSWORD")
+    GARMIN_PASSWORD = os.getenv("GARMIN_PASSWORD")
 
 
 try:
-	secret = open("/run/secrets/trainerroad_username")
-	TRAINERROAD_USERNAME = secret.read()
-	secret.close()
+    secret = open("/run/secrets/trainerroad_username")
+    TRAINERROAD_USERNAME = secret.read()
+    secret.close()
 except Exception:
-	TRAINERROAD_USERNAME = ''
+    TRAINERROAD_USERNAME = ""
 
 try:
-	secret = open("/run/secrets/trainerroad_password")
-	TRAINERROAD_PASSWORD = secret.read()
-	secret.close()
+    secret = open("/run/secrets/trainerroad_password")
+    TRAINERROAD_PASSWORD = secret.read()
+    secret.close()
 except Exception:
-	TRAINERROAD_PASSWORD = ''
+    TRAINERROAD_PASSWORD = ""
 
 if "TR_USERNAME" in os.environ:
-	TRAINERROAD_USERNAME = os.getenv("TRAINERROAD_USERNAME")
+    TRAINERROAD_USERNAME = os.getenv("TRAINERROAD_USERNAME")
 
 if "TR_PASSWORD" in os.environ:
-	TRAINERROAD_PASSWORD = os.getenv("TRAINERROAD_PASSWORD")
+    TRAINERROAD_PASSWORD = os.getenv("TRAINERROAD_PASSWORD")
 
 
 def get_args():
     parser = argparse.ArgumentParser(
-        description=('A tool for synchronisation of Withings '
-                     '(ex. Nokia Health Body) to Garmin Connect'
-                     ' and Trainer Road or to provide a json string.')
+        description=(
+            "A tool for synchronisation of Withings "
+            "(ex. Nokia Health Body) to Garmin Connect"
+            " and Trainer Road or to provide a json string."
+        )
     )
 
     def date_parser(s):
-        return datetime.strptime(s, '%Y-%m-%d')
+        return datetime.strptime(s, "%Y-%m-%d")
 
-    parser.add_argument('--garmin-username', '--gu',
-                        default=GARMIN_USERNAME,
-                        type=str,
-                        metavar='GARMIN_USERNAME',
-                        help='username to log in to Garmin Connect.')
-    parser.add_argument('--garmin-password', '--gp',
-                        default=GARMIN_PASSWORD,
-                        type=str,
-                        metavar='GARMIN_PASSWORD',
-                        help='password to log in to Garmin Connect.')
+    parser.add_argument(
+        "--garmin-username",
+        "--gu",
+        default=GARMIN_USERNAME,
+        type=str,
+        metavar="GARMIN_USERNAME",
+        help="username to log in to Garmin Connect.",
+    )
+    parser.add_argument(
+        "--garmin-password",
+        "--gp",
+        default=GARMIN_PASSWORD,
+        type=str,
+        metavar="GARMIN_PASSWORD",
+        help="password to log in to Garmin Connect.",
+    )
 
-    parser.add_argument('--trainerroad-username', '--tu', 
-                        default=TRAINERROAD_USERNAME,
-                        type=str,
-                        metavar='TRAINERROAD_USERNAME',
-                        help='username to log in to TrainerRoad.')
-    parser.add_argument('--trainerroad-password', '--tp', 
-                        default=TRAINERROAD_PASSWORD,
-                        type=str,
-                        metavar='TRAINERROAD_PASSWORD',
-                        help='password to log in to TrainerRoad.')
+    parser.add_argument(
+        "--trainerroad-username",
+        "--tu",
+        default=TRAINERROAD_USERNAME,
+        type=str,
+        metavar="TRAINERROAD_USERNAME",
+        help="username to log in to TrainerRoad.",
+    )
+    parser.add_argument(
+        "--trainerroad-password",
+        "--tp",
+        default=TRAINERROAD_PASSWORD,
+        type=str,
+        metavar="TRAINERROAD_PASSWORD",
+        help="password to log in to TrainerRoad.",
+    )
 
-    parser.add_argument('--fromdate', '-f',
-                        type=date_parser,
-                        metavar='DATE')
-    parser.add_argument('--todate', '-t',
-                        type=date_parser,
-                        default=date.today(),
-                        metavar='DATE')
+    parser.add_argument("--fromdate", "-f", type=date_parser, metavar="DATE")
+    parser.add_argument(
+        "--todate", "-t", type=date_parser, default=date.today(), metavar="DATE"
+    )
 
-    parser.add_argument('--to-fit', '-F',
-                        action='store_true',
-                        help=('Write output file in FIT format.'))
-    parser.add_argument('--to-json', '-J',
-                        action='store_true',
-                        help=('Write output file in JSON format.'))
-    parser.add_argument('--output', '-o',
-                        type=str,
-                        metavar='BASENAME',
-                        help=('Write downloaded measurements to file.'))
+    parser.add_argument(
+        "--to-fit", "-F", action="store_true", help=("Write output file in FIT format.")
+    )
+    parser.add_argument(
+        "--to-json",
+        "-J",
+        action="store_true",
+        help=("Write output file in JSON format."),
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        metavar="BASENAME",
+        help=("Write downloaded measurements to file."),
+    )
 
-    parser.add_argument('--no-upload',
-                        action='store_true',
-                        help=('Won\'t upload to Garmin Connect or '
-                              'TrainerRoad.'))
-    parser.add_argument('--verbose', '-v',
-                        action='store_true',
-                        help='Run verbosely')
+    parser.add_argument(
+        "--no-upload",
+        action="store_true",
+        help=("Won't upload to Garmin Connect or " "TrainerRoad."),
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Run verbosely")
 
     return parser.parse_args()
 
 
-def sync(garmin_username, garmin_password,
-         trainerroad_username, trainerroad_password,
-         fromdate, todate,
-         to_fit, to_json, output,
-         no_upload, verbose):
+def sync(
+    garmin_username,
+    garmin_password,
+    trainerroad_username,
+    trainerroad_password,
+    fromdate,
+    todate,
+    to_fit,
+    to_json,
+    output,
+    no_upload,
+    verbose,
+):
 
-    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO,
-                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-                        stream=sys.stdout)
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stdout,
+    )
 
     if to_json:
         json_data = {}
@@ -139,7 +165,11 @@ def sync(garmin_username, garmin_password,
         startdate = int(time.mktime(fromdate.timetuple()))
 
     enddate = int(time.mktime(todate.timetuple())) + 86399
-    logging.info("Fetching measurements from %s to %s", time.strftime('%Y-%m-%d %H:%M', time.gmtime(startdate)), time.strftime('%Y-%m-%d %H:%M', time.gmtime(enddate)))
+    logging.info(
+        "Fetching measurements from %s to %s",
+        time.strftime("%Y-%m-%d %H:%M", time.gmtime(startdate)),
+        time.strftime("%Y-%m-%d %H:%M", time.gmtime(enddate)),
+    )
 
     height = withings.getHeight()
 
@@ -147,7 +177,7 @@ def sync(garmin_username, garmin_password,
 
     # Only upload if there are measurement returned
     if groups is None or len(groups) == 0:
-        logging.error('No measurements to upload for date or period specified')
+        logging.error("No measurements to upload for date or period specified")
         return -1
 
     # Save this sync so we don't re-download the same data again (if no range has been specified)
@@ -155,7 +185,7 @@ def sync(garmin_username, garmin_password,
         withings.setLastSync()
 
     # Create FIT file
-    logging.debug('Generating fit file...')
+    logging.debug("Generating fit file...")
     fit = FitEncoder_Weight()
     fit.write_file_info()
     fit.write_file_creator()
@@ -174,8 +204,10 @@ def sync(garmin_username, garmin_password,
         raw_data = group.get_raw_data()
 
         if weight is None:
-            logging.info('This Withings metric contains no weight data.  Not syncing...')
-            logging.debug('Detected data: ')
+            logging.info(
+                "This Withings metric contains no weight data.  Not syncing..."
+            )
+            logging.debug("Detected data: ")
             for dataentry in raw_data:
                 logging.debug(dataentry)
             continue
@@ -191,31 +223,41 @@ def sync(garmin_username, garmin_password,
             percent_hydration = None
 
         fit.write_device_info(timestamp=dt)
-        fit.write_weight_scale(timestamp=dt,
-                               weight=weight,
-                               percent_fat=fat_ratio,
-                               percent_hydration=percent_hydration,
-                               bone_mass=bone_mass,
-                               muscle_mass=muscle_mass,
-                               bmi=bmi)
+        fit.write_weight_scale(
+            timestamp=dt,
+            weight=weight,
+            percent_fat=fat_ratio,
+            percent_hydration=percent_hydration,
+            bone_mass=bone_mass,
+            muscle_mass=muscle_mass,
+            bmi=bmi,
+        )
 
-        logging.debug('Record: %s weight=%s kg, '
-                      'fat_ratio=%s %%, '
-                      'muscle_mass=%s kg, '
-                      'hydration=%s %%, '
-                      'bone_mass=%s kg, '
-                      'bmi=%s',
-                      dt, weight, fat_ratio,
-                      muscle_mass, hydration,
-                      bone_mass, bmi)
+        logging.debug(
+            "Record: %s weight=%s kg, "
+            "fat_ratio=%s %%, "
+            "muscle_mass=%s kg, "
+            "hydration=%s %%, "
+            "bone_mass=%s kg, "
+            "bmi=%s",
+            dt,
+            weight,
+            fat_ratio,
+            muscle_mass,
+            hydration,
+            bone_mass,
+            bmi,
+        )
         if to_json:
-            json_data[str(dt)] = {'unit': 'kg', \
-                    'weight': weight, \
-                    'fat_ratio': fat_ratio, \
-                    'muscle_mass': muscle_mass, \
-                    'hydration_ratio': hydration, \
-                    'bone_mass': bone_mass, \
-                    'bmi': bmi}
+            json_data[str(dt)] = {
+                "unit": "kg",
+                "weight": weight,
+                "fat_ratio": fat_ratio,
+                "muscle_mass": muscle_mass,
+                "hydration_ratio": hydration,
+                "bone_mass": bone_mass,
+                "bmi": bmi,
+            }
 
         if last_dt is None or dt > last_dt:
             last_dt = dt
@@ -224,63 +266,62 @@ def sync(garmin_username, garmin_password,
     fit.finish()
 
     if last_weight is None:
-        logging.error('Invalid weight')
+        logging.error("Invalid weight")
         return -1
 
     if output is not None:
         if to_fit:
-            filename = output + '.fit'
-            logging.info('Writing file to {}'.format(filename))
+            filename = output + ".fit"
+            logging.info("Writing file to {}".format(filename))
             try:
                 fitfile = open(filename, "wb")
                 fitfile.write(fit.getvalue())
                 fitfile.close()
             except (OSError, IOError):
-                logging.error('Unable to open output file!')
+                logging.error("Unable to open output file!")
         if to_json:
-            filename = output + '.json'
-            logging.info('Writing file to {}'.format(filename))
+            filename = output + ".json"
+            logging.info("Writing file to {}".format(filename))
             try:
                 jsonfile = open(filename, "w")
-                json.dump(json_data, jsonfile, indent = 4)
+                json.dump(json_data, jsonfile, indent=4)
                 jsonfile.close()
             except (OSError, IOError):
-                logging.error('Unable to open output file!')
+                logging.error("Unable to open output file!")
 
     if no_upload:
-        logging.info('Skipping upload')
+        logging.info("Skipping upload")
         return 0
 
     # Upload to Trainer Road
     if trainerroad_username:
-        logging.info('Trainerroad username set -- attempting to sync')
-        logging.info(' Last weight {}'.format(last_weight))
-        logging.info(' Measured {}'.format(last_dt))
+        logging.info("Trainerroad username set -- attempting to sync")
+        logging.info(" Last weight {}".format(last_weight))
+        logging.info(" Measured {}".format(last_dt))
 
         tr = TrainerRoad(trainerroad_username, trainerroad_password)
         tr.connect()
 
-        logging.info(f'Current TrainerRoad weight: {tr.weight} kg ')
-        logging.info(f'Updating TrainerRoad weight to {last_weight} kg')
+        logging.info(f"Current TrainerRoad weight: {tr.weight} kg ")
+        logging.info(f"Updating TrainerRoad weight to {last_weight} kg")
 
         tr.weight = round(last_weight, 1)
         tr.disconnect()
 
-        logging.info('TrainerRoad update done!')
+        logging.info("TrainerRoad update done!")
     else:
-        logging.info('No Trainerroad username or a new measurement '
-                     '- skipping sync')
+        logging.info("No Trainerroad username or a new measurement " "- skipping sync")
 
     # Upload to Garmin Connect
     if garmin_username:
         garmin = GarminConnect()
         session = garmin.login(garmin_username, garmin_password)
-        logging.debug('attempting to upload fit file...')
+        logging.debug("attempting to upload fit file...")
         r = garmin.upload_file(fit.getvalue(), session)
         if r:
-            logging.info('Fit file uploaded to Garmin Connect')
+            logging.info("Fit file uploaded to Garmin Connect")
     else:
-        logging.info('No Garmin username - skipping sync')
+        logging.info("No Garmin username - skipping sync")
 
 
 def main():

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -281,7 +281,7 @@ def sync(
             filename = output + ".json"
             logging.info("Writing file to %s.", filename)
             try:
-                with open(filename, "w") as jsonfile:
+                with open(filename, "w", encoding="utf-8") as jsonfile:
                     json.dump(json_data, jsonfile, indent=4)
             except (OSError, IOError):
                 logging.error("Unable to open output file!")

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -319,6 +319,7 @@ def sync(
             logging.info("Fit file uploaded to Garmin Connect")
     else:
         logging.info("No Garmin username - skipping sync")
+    return 0
 
 
 def main():

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -1,3 +1,4 @@
+"""This module syncs measurement data from Withings to Garmin a/o TrainerRoad."""
 import argparse
 import time
 import sys
@@ -56,6 +57,7 @@ if "TR_PASSWORD" in os.environ:
 
 
 def get_args():
+    """get command-line arguments"""
     parser = argparse.ArgumentParser(
         description=(
             "A tool for synchronisation of Withings "
@@ -146,6 +148,7 @@ def sync(
     no_upload,
     verbose,
 ):
+    """Sync measurements from Withings to Garmin a/o TrainerRoad"""
 
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,
@@ -325,6 +328,7 @@ def sync(
 
 
 def main():
+    """Main"""
     args = get_args()
 
     sync(**vars(args))

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -15,16 +15,14 @@ from withings_sync.fit import FitEncoder_Weight
 
 
 try:
-    secret = open("/run/secrets/garmin_username")
-    GARMIN_USERNAME = secret.read()
-    secret.close()
+    with open("/run/secrets/garmin_username", encoding="utf-8") as secret:
+        GARMIN_USERNAME = secret.read()
 except Exception:
     GARMIN_USERNAME = ""
 
 try:
-    secret = open("/run/secrets/garmin_password")
-    GARMIN_PASSWORD = secret.read()
-    secret.close()
+    with open("/run/secrets/garmin_password", encoding="utf-8") as secret:
+        GARMIN_PASSWORD = secret.read()
 except Exception:
     GARMIN_PASSWORD = ""
 
@@ -36,16 +34,14 @@ if "GC_PASSWORD" in os.environ:
 
 
 try:
-    secret = open("/run/secrets/trainerroad_username")
-    TRAINERROAD_USERNAME = secret.read()
-    secret.close()
+    with open("/run/secrets/trainerroad_username", encoding="utf-8") as secret:
+        TRAINERROAD_USERNAME = secret.read()
 except Exception:
     TRAINERROAD_USERNAME = ""
 
 try:
-    secret = open("/run/secrets/trainerroad_password")
-    TRAINERROAD_PASSWORD = secret.read()
-    secret.close()
+    with open("/run/secrets/trainerroad_password", encoding="utf-8") as secret:
+        TRAINERROAD_PASSWORD = secret.read()
 except Exception:
     TRAINERROAD_PASSWORD = ""
 
@@ -277,18 +273,16 @@ def sync(
             filename = output + ".fit"
             logging.info("Writing file to {}".format(filename))
             try:
-                fitfile = open(filename, "wb")
-                fitfile.write(fit.getvalue())
-                fitfile.close()
+                with open(filename, "wb") as fitfile:
+                    fitfile.write(fit.getvalue())
             except (OSError, IOError):
                 logging.error("Unable to open output file!")
         if to_json:
             filename = output + ".json"
             logging.info("Writing file to {}".format(filename))
             try:
-                jsonfile = open(filename, "w")
-                json.dump(json_data, jsonfile, indent=4)
-                jsonfile.close()
+                with open(filename, "w") as jsonfile:
+                    json.dump(json_data, jsonfile, indent=4)
             except (OSError, IOError):
                 logging.error("Unable to open output file!")
 


### PR DESCRIPTION
Good afternoon, 

This PR is a first attempt to add some Python Code Style to the code with checks vs black & pylint.  
Rationale: my editor tends to complain about this on every save.  

For now, it's only done for one file (sync.py) and not fully completed yet (see pylint output below) I am wondering what your opinions are about this.  

Fixing the remaining 3 recommendations require some code restructuring, I'll leave that for a follow-up PR. 
```
Module withings_sync.sync
sync.py:134:0: R0914: Too many local variables (26/15) (too-many-locals)
sync.py:134:0: R0912: Too many branches (26/12) (too-many-branches)
sync.py:134:0: R0915: Too many statements (93/50) (too-many-statements)

------------------------------------------------------------------
Your code has been rated at 9.81/10 (previous run: 9.81/10, +0.00)
```

Please test as I don't have this running in a container nor do I have a trainerroad subscription.  