### PR TITLE
sync.py: add python version check / requires python3

### DIFF
--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -286,4 +286,8 @@ def sync(garmin_username, garmin_password,
 def main():
     args = get_args()
 
+    if sys.version_info < (3, 0):
+        print("Sorry, requires Python3, not Python2.")
+        sys.exit(1)
+
     sync(**vars(args))


### PR DESCRIPTION
Gives more details on what is going on in cases such as https://github.com/jaroslawhartman/withings-sync/issues/44