### PR TITLE
fix Dockerfile: downgrade charset-normalizer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3.9
 
 RUN apt-get update && \
 	apt-get install -y \
-		python3-lxml
+		python3-lxml \
+        # downgrade charset-normalizer, because requests need version 2.0
+        && pip install -Iv charset-normalizer==2.0.0
 
 RUN mkdir -p /src
 COPY . /src


### PR DESCRIPTION
request has a fix dependency on charset-normalizer charset_normalizer~=2.0.0 (see https://requests.readthedocs.io/en/latest/user/advanced/#encodings)

Is this the way this issue should be resolved? I'm happy about every comment or suggestion.