### PR TITLE
Fix K8s cron example to not run every minute

### DIFF
--- a/contrib/k8s-job.yaml
+++ b/contrib/k8s-job.yaml
@@ -84,6 +84,6 @@ spec:
             persistentVolumeClaim:
               claimName: withings-oauth-cache
 
-  schedule: '* */3 * * *'
+  schedule: '0 */3 * * *'
   successfulJobsHistoryLimit: 3
 


### PR DESCRIPTION
The minute field in the current K8s cron example is `*`, which means that it will run every minute (0-60) of every qualifying third hour (`*/3`).

Based on the documentation, I don't think that's the intention.