### PR TITLE
Store lastsync info only if no error occurred

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.egg-info/
 dist/
+.idea
+*.json

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="withings-sync",
-    version="3.5",
+    version="3.5.1",
     author="Masayuki Hamasaki, Steffen Vogel",
     author_email="post@steffenvogel.de",
     description="A tool for synchronisation of Withings (ex. Nokia Health Body) to Garmin Connect and Trainer Road.",


### PR DESCRIPTION
During sync error when dealing with #80 I noticed that last sync info gets stored even if no data were uploaded/synchronized. I changed the order of call to store last sync only if no exception/error occurred before.   