### PR TITLE
Strip whitespace from docker-secrets

### DIFF
--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -16,13 +16,13 @@ from withings_sync.fit import FitEncoder_Weight
 
 try:
     with open("/run/secrets/garmin_username", encoding="utf-8") as secret:
-        GARMIN_USERNAME = secret.read()
+        GARMIN_USERNAME = secret.read().strip()
 except OSError:
     GARMIN_USERNAME = ""
 
 try:
     with open("/run/secrets/garmin_password", encoding="utf-8") as secret:
-        GARMIN_PASSWORD = secret.read()
+        GARMIN_PASSWORD = secret.read().strip()
 except OSError:
     GARMIN_PASSWORD = ""
 
@@ -35,13 +35,13 @@ if "GARMIN_PASSWORD" in os.environ:
 
 try:
     with open("/run/secrets/trainerroad_username", encoding="utf-8") as secret:
-        TRAINERROAD_USERNAME = secret.read()
+        TRAINERROAD_USERNAME = secret.read().strip()
 except OSError:
     TRAINERROAD_USERNAME = ""
 
 try:
     with open("/run/secrets/trainerroad_password", encoding="utf-8") as secret:
-        TRAINERROAD_PASSWORD = secret.read()
+        TRAINERROAD_PASSWORD = secret.read().strip()
 except OSError:
     TRAINERROAD_PASSWORD = ""
 

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -16,17 +16,13 @@ from withings_sync.fit import FitEncoder_Weight
 
 try:
     with open("/run/secrets/garmin_username", encoding="utf-8") as secret:
-        GARMIN_USERNAME = secret.read().strip()
-        if GARMIN_USERNAME != secret.read():
-             logging.warn("GARMIN_USERNAME contains whitespace at start or end, this could be a conf error.")
+        GARMIN_USERNAME = secret.read().strip("\n")
 except OSError:
     GARMIN_USERNAME = ""
 
 try:
     with open("/run/secrets/garmin_password", encoding="utf-8") as secret:
-        GARMIN_PASSWORD = secret.read().strip()
-        if GARMIN_PASSWORD != secret.read():
-             logging.warn("GARMIN_PASSWORD contains whitespace at start or end, this could be a conf error.")
+        GARMIN_PASSWORD = secret.read().strip("\n")
 except OSError:
     GARMIN_PASSWORD = ""
 
@@ -39,17 +35,13 @@ if "GARMIN_PASSWORD" in os.environ:
 
 try:
     with open("/run/secrets/trainerroad_username", encoding="utf-8") as secret:
-        TRAINERROAD_USERNAME = secret.read().strip()
-        if TRAINERROAD_USERNAME != secret.read():
-             logging.warn("TRAINERROAD_USERNAME contains whitespace at start or end, this could be a conf error.")
+        TRAINERROAD_USERNAME = secret.read().strip("\n")
 except OSError:
     TRAINERROAD_USERNAME = ""
 
 try:
     with open("/run/secrets/trainerroad_password", encoding="utf-8") as secret:
-        TRAINERROAD_PASSWORD = secret.read().strip()
-        if TRAINERROAD_PASSWORD != secret.read():
-             logging.warn("TRAINERROAD_PASSWORD contains whitespace at start or end, this could be a conf error.")
+        TRAINERROAD_PASSWORD = secret.read().strip("\n")
 except OSError:
     TRAINERROAD_PASSWORD = ""
 

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -17,12 +17,16 @@ from withings_sync.fit import FitEncoder_Weight
 try:
     with open("/run/secrets/garmin_username", encoding="utf-8") as secret:
         GARMIN_USERNAME = secret.read().strip()
+        if GARMIN_USERNAME != secret.read():
+             logging.warn("GARMIN_USERNAME contains whitespace at start or end, this could be a conf error.")
 except OSError:
     GARMIN_USERNAME = ""
 
 try:
     with open("/run/secrets/garmin_password", encoding="utf-8") as secret:
         GARMIN_PASSWORD = secret.read().strip()
+        if GARMIN_PASSWORD != secret.read():
+             logging.warn("GARMIN_PASSWORD contains whitespace at start or end, this could be a conf error.")
 except OSError:
     GARMIN_PASSWORD = ""
 
@@ -36,12 +40,16 @@ if "GARMIN_PASSWORD" in os.environ:
 try:
     with open("/run/secrets/trainerroad_username", encoding="utf-8") as secret:
         TRAINERROAD_USERNAME = secret.read().strip()
+        if TRAINERROAD_USERNAME != secret.read():
+             logging.warn("TRAINERROAD_USERNAME contains whitespace at start or end, this could be a conf error.")
 except OSError:
     TRAINERROAD_USERNAME = ""
 
 try:
     with open("/run/secrets/trainerroad_password", encoding="utf-8") as secret:
         TRAINERROAD_PASSWORD = secret.read().strip()
+        if TRAINERROAD_PASSWORD != secret.read():
+             logging.warn("TRAINERROAD_PASSWORD contains whitespace at start or end, this could be a conf error.")
 except OSError:
     TRAINERROAD_PASSWORD = ""
 


### PR DESCRIPTION
When reading from docker secrets, the usename and password must be stripped of trailing whitespace. This will possibly fix many of the 401-errors people are seeing.  (At least that was the problem here).