### PR TITLE
chore: change pypa gh action publish to release

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -33,6 +33,6 @@ jobs:
 
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
gh-action-pypi-publish: The master branch version has been sunset. Please, change the GitHub Action version you use from master to release/v1 or use an exact tag, or a full Git commit SHA.

I found this message, when investigation why the build failed:

> You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use "pypa/gh-action-pypi-publish@release/v1". If you feel adventurous, you may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. A more general recommendation is to pin to exact tags or commit shas.

This PR switches to the release version v1 as supposed in [their repository](https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-).