### PR TITLE
Fix trainerroad sync problem

### DIFF
--- a/withings_sync/trainerroad.py
+++ b/withings_sync/trainerroad.py
@@ -13,7 +13,7 @@ class TrainerRoad:
     _weight = 'Weight'
     _units_metric = 'kmh'
     _units_imperial = 'mph'
-    _input_data_names = (_ftp, _weight, 'Marketing')
+    _input_data_names = (_ftp, _weight, 'Marketing', 'DateOfBirth')
     _select_data_names = ('TimeZoneId', 'IsPrivate',
                           'Units', 'IsVirtualPowerEnabled')
     _numerical_verify = (_ftp, _weight)


### PR DESCRIPTION
Hi, I found a fix for #83 

It seems that TrainerRoad is requiring this additional key-value pair to be present in the POST request