### PR TITLE
Fix the incorrect date/time log output generated by sync.py

### DIFF
--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -422,8 +422,8 @@ def sync():
     enddate = int(time.mktime(ARGS.todate.timetuple())) + 86399
     logging.info(
         "Fetching measurements from %s to %s",
-        time.strftime("%Y-%m-%d %H:%M", time.gmtime(startdate)),
-        time.strftime("%Y-%m-%d %H:%M", time.gmtime(enddate)),
+        time.strftime("%Y-%m-%d %H:%M", time.localtime(startdate)),
+        time.strftime("%Y-%m-%d %H:%M", time.localtime(enddate)),
     )
 
     height = withings.get_height()


### PR DESCRIPTION
Apology in advance, my English might not make sense at all, or my understanding of codebase is totally off.

This will hopefully fix the incorrect date/time in log output.

Let's say that `last_sync` in `.withings_user.json` is as follows:

```
 "last_sync": 1680243105,
```
which is equal to "2023/3/31 15:11:45" in JST(UTC+9), and matches the timezone of my pc.

When there is nothing to sync, log output should look like this:

```
2023-03-31 15:26:10,748 - withings - INFO - Refresh Access Token
2023-03-31 15:26:11,913 - root - INFO - Fetching measurements from 2023-03-31 15:11 to 2023-03-31 23:59
2023-03-31 15:26:12,890 - withings - INFO - Get Measurements
2023-03-31 15:26:13,850 - root - ERROR - No measurements to upload for date or period specified
```

On the 2nd line, it says that `withings-sync` is fetching measurements from the "last_sync" date and time, and to the last minute of same date.

However, withings-sync v3.6.0 outputs a following log:

```
2023-03-31 15:23:37,132 - withings - INFO - Refresh Access Token
2023-03-31 15:23:38,369 - root - INFO - Fetching measurements from 2023-03-31 06:11 to 2023-03-31 14:59
2023-03-31 15:23:39,293 - withings - INFO - Get Measurements
2023-03-31 15:23:40,229 - root - ERROR - No measurements to upload for date or period specified
```

You can tell from the 2nd line that it does not take into account the time difference between UTC and the local timezone(in this case, +9 hours), and prints out the date and time in UTC.

I understand that the actual sync is executed based on the local time, not UTC. But still, this log output is really confusing when debugging, as the timestamp of log(e.g. "2023-03-31 15:23:38,369") is local time, but the "from, to date/time" in this line of log is in UTC.