### PR TITLE
Update release version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="withings-sync",
-    version="4.1.0",
+    version="4.2.1",
     author="Masayuki Hamasaki, Steffen Vogel",
     author_email="post@steffenvogel.de",
     description="A tool for synchronisation of Withings (ex. Nokia Health Body) to Garmin Connect and Trainer Road.",


### PR DESCRIPTION
Lack of version change will result in wrong version reporting in debug logging.

I propose a quick release to go from 4.2.0 to 4.2.1 just to fix this. 