### PR TITLE
Add gar_wg_state and gar_bp_state variables to Sync.py

### DIFF
--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -464,16 +464,19 @@ def sync():
                     logging.info(
                         "Fit file with weight information uploaded to Garmin Connect"
                     )
+                    # Save this sync so we don't re-download the same data again (if no range has been specified)
+                    if not ARGS.fromdate:
+                        withings.set_lastsync()
+
             if fit_data_blood_pressure is not None:
                 gar_bp_state = sync_garmin(fit_data_blood_pressure)
                 if gar_bp_state:
                     logging.info(
                         "Fit file with blood pressure information uploaded to Garmin Connect"
                     )
-            if gar_wg_state or gar_bp_state:
-                # Save this sync so we don't re-download the same data again (if no range has been specified)
-                if not ARGS.fromdate:
-                    withings.set_lastsync()
+                    # Save this sync so we don't re-download the same data again (if no range has been specified)
+                    if not ARGS.fromdate:
+                        withings.set_lastsync()
         else:
             logging.info("No Garmin username - skipping sync")
     else:

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -472,7 +472,6 @@ def sync():
                     logging.info(
                         "Fit file with blood pressure information uploaded to Garmin Connect"
                     )
-                    # Save this sync so we don't re-download the same data again (if no range has been specified)
             if gar_wg_state or gar_bp_state:
                 # Save this sync so we don't re-download the same data again (if no range has been specified)
                 if not ARGS.fromdate:

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -458,16 +458,14 @@ def sync():
             fit_data_weight is not None or fit_data_blood_pressure is not None
         ):
             logging.debug("attempting to upload fit file...")
+            gar_wg_state = None
+            gar_bp_state = None
             if fit_data_weight is not None:
                 gar_wg_state = sync_garmin(fit_data_weight)
                 if gar_wg_state:
                     logging.info(
                         "Fit file with weight information uploaded to Garmin Connect"
                     )
-                    # Save this sync so we don't re-download the same data again (if no range has been specified)
-                    if not ARGS.fromdate:
-                        withings.set_lastsync()
-
             if fit_data_blood_pressure is not None:
                 gar_bp_state = sync_garmin(fit_data_blood_pressure)
                 if gar_bp_state:
@@ -475,8 +473,10 @@ def sync():
                         "Fit file with blood pressure information uploaded to Garmin Connect"
                     )
                     # Save this sync so we don't re-download the same data again (if no range has been specified)
-                    if not ARGS.fromdate:
-                        withings.set_lastsync()
+            if gar_wg_state or gar_bp_state:
+                # Save this sync so we don't re-download the same data again (if no range has been specified)
+                if not ARGS.fromdate:
+                    withings.set_lastsync()
         else:
             logging.info("No Garmin username - skipping sync")
     else:


### PR DESCRIPTION
Error accessing variable 'gar_wg_state' when only using Withings blood pressure device.  Moved set_lastsyn() under reach fit_data if statements so the other variable isn't used..

UnboundLocalError: cannot access local variable 'gar_wg_state' where it is not associated with a value