### PR TITLE
fix: use correct image in k8s-deployment.yaml

### DIFF
--- a/contrib/k8s-deployment.yaml
+++ b/contrib/k8s-deployment.yaml
@@ -32,8 +32,8 @@ metadata:
 type: Opaque
 stringData:
   # NOT base64 
-  GARMIN_PASSWORD: "someone@example.com"
-  GARMIN_USERNAME: "password-goes-here"
+  GARMIN_USERNAME: "someone@example.com"
+  GARMIN_PASSWORD: "password-goes-here"
   TRAINERROAD_PASSWORD: ""
   TRAINERROAD_USERNAME: ""
 
@@ -74,7 +74,7 @@ spec:
     spec:
       containers:
       - name: withings-sync
-        image: docker.io/stv0g/withings-sync
+        image: ghcr.io/jaroslawhartman/withings-sync:master
         imagePullPolicy: IfNotPresent
 
         # override $HOME to put our oauth file in a known place

--- a/contrib/k8s-job.yaml
+++ b/contrib/k8s-job.yaml
@@ -11,8 +11,8 @@ metadata:
 type: Opaque
 stringData:
   # NOT base64 
-  GARMIN_PASSWORD: "someone@example.com"
-  GARMIN_USERNAME: "password-goes-here"
+  GARMIN_USERNAME: "someone@example.com"
+  GARMIN_PASSWORD: "password-goes-here"
   TRAINERROAD_PASSWORD: ""
   TRAINERROAD_USERNAME: ""
 
@@ -39,7 +39,7 @@ spec:
   volumeMode: Filesystem
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: withings-garmin-sync


### PR DESCRIPTION
fix: set apiVersion of chronjob to `batch/v1` as `batch/v1beta1` is deprecated (check https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125)