### PR TITLE
Don't pin garth version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "lxml==5.2.2",
         "requests==2.31.0",
-        "garth==0.4.46",
+        "garth>=0.4.46",
         "python-dotenv"],
     entry_points={
         "console_scripts": ["withings-sync=withings_sync.sync:main"],


### PR DESCRIPTION
I cannot install garth > 0.4.7 together with latest version withings-sync, and I need both, if there is no specific reason to pin please merge this in new version

Also consider implementing pyproject.toml because of this:  DEPRECATION: withings-sync is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559