### PR TITLE
Add support for specifying credential files via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ You can also populate the following 'secrets' files to provide the Garmin and/or
 - `/run/secrets/trainerroad_username`
 - `/run/secrets/trainerroad_password`
 
+Alternatively, you can specify secrets files via environment variables:
+
+- `GARMIN_USERNAME_FILE`
+- `GARMIN_PASSWORD_FILE`
+- `TRAINERROAD_USERNAME_FILE`
+- `TRAINERROAD_PASSWORD_FILE`
+
 Secrets are useful in an orchestrated container context — see the [Docker Swarm](https://docs.docker.com/engine/swarm/secrets/) or [Rancher](https://rancher.com/docs/rancher/v1.6/en/cattle/secrets/) docs for more information on how to securely inject secrets into a container.
 
 ### Order of priority for credentials
@@ -70,8 +77,9 @@ Secrets are useful in an orchestrated container context — see the [Docker Swar
 In the case of credentials being available via multiple means (e.g. [environment variables](#providing-credentials-via-environment-variables) and [secrets files](#providing-credentials-via-secrets-files)), the order of resolution for determining which credentials to use is as follows, with later methods overriding credentials supplied by an earlier method:
 
 1. Read secrets file(s)
-2. Read environment variable(s), variables set explicitly take precedence over values from a `.env` file.
-3. Use command invocation argument(s)
+2. Read secrets file(s) specified by environment variables
+3. Read environment variable(s), variables set explicitly take precedence over values from a `.env` file.
+4. Use command invocation argument(s)
 
 ### Obtaining Withings Authorization Code
 

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -21,25 +21,32 @@ from withings_sync.trainerroad import TrainerRoad
 from withings_sync.fit import FitEncoderWeight, FitEncoderBloodPressure
 
 
-def load_variable(env_var, secrets_file):
+def load_variable(env_var, secrets_var, secrets_file):
     """Load a variable from an environment variable or from a secrets file"""
-    # Try to read the value from the secrets file. Silently fail if the file
-    # cannot be read and use an empty value
+    value = os.getenv(env_var, "")
+    if value:
+        return value
+
+    try:
+        with open(os.getenv(secrets_var), encoding='utf-8') as secret:
+            value = secret.read().strip("\n")
+            if value:
+                return value
+    except OSError:
+        pass
+
     try:
         with open(secrets_file, encoding='utf-8') as secret:
             value = secret.read().strip("\n")
     except OSError:
-        value = ""
+        pass
 
-    # Load variable from environment if it exists, otherwise use the
-    # value read from the secrets file.
-    return os.getenv(env_var, value)
+    return value
 
-
-GARMIN_USERNAME = load_variable('GARMIN_USERNAME', "/run/secrets/garmin_username")
-GARMIN_PASSWORD = load_variable('GARMIN_PASSWORD', "/run/secrets/garmin_password")
-TRAINERROAD_USERNAME = load_variable('TRAINERROAD_USERNAME', "/run/secrets/trainerroad_username")
-TRAINERROAD_PASSWORD = load_variable('TRAINERROAD_PASSWORD', "/run/secrets/trainerroad_password")
+GARMIN_USERNAME = load_variable('GARMIN_USERNAME', 'GARMIN_USERNAME_FILE', "/run/secrets/garmin_username")
+GARMIN_PASSWORD = load_variable('GARMIN_PASSWORD', 'GARMIN_PASSWORD_FILE', "/run/secrets/garmin_password")
+TRAINERROAD_USERNAME = load_variable('TRAINERROAD_USERNAME', 'TRAINERROAD_USERNAME_FILE', "/run/secrets/trainerroad_username")
+TRAINERROAD_PASSWORD = load_variable('TRAINERROAD_PASSWORD', 'TRAINERROAD_PASSWORD_FILE', "/run/secrets/trainerroad_password")
 
 
 

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -28,10 +28,12 @@ def load_variable(env_var, secrets_var, secrets_file):
         return value
 
     try:
-        with open(os.getenv(secrets_var), encoding='utf-8') as secret:
-            value = secret.read().strip("\n")
-            if value:
-                return value
+        path = os.getenv(secrets_var)
+        if path:
+            with open(path, encoding='utf-8') as secret:
+                value = secret.read().strip("\n")
+                if value:
+                    return value
     except OSError:
         pass
 


### PR DESCRIPTION
Allows specifying paths to credential files (Garmin/TrainerRoad username/password) via environment variables (e.g. GARMIN_PASSWORD_FILE).

Motivation: I'm running withings-sync via a [systemd service](https://github.com/aidengindin/nixos-config/blob/service/withings-sync/services/withings-sync.nix) for multiple people, and I want to load credentials from a file. The current implementation, with hardcoded paths, doesn't fit my use case as it only works with one user.

Priority for loading credentials is as follows:

1. Environment variable (direct)
2. Environment variable (file)
3. Hardcoded file path

This change is fully backwards compatible; existing setups will not be affected.

I have tested this on my system and confirmed that it works with Garmin. I don't use TrainerRoad, but as the implementation is identical for all credentials (they all use the `load_variable` function), it should work as well.

I've updated the README to explain this functionality.

Example usage:

```bash
export GARMIN_USERNAME_FILE=/path/to/garmin-username.txt
export GARMIN_PASSWORD_FILE=/path/to/garmin-password.txt

withings-sync
```