### PR TITLE
fix: prevent deletion of valid weight data when multiple measurement groups share same timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,9 @@ options:
   --features BLOOD_PRESSURE [BLOOD_PRESSURE ...]
                         Enable Features like BLOOD_PRESSURE.
   --verbose, -v         Run verbosely.
+  --dump-raw, -R        Dump the raw Withings API JSON for the selected date range to a file. 
+                        If --output is provided, the file will be named BASENAME.withings_raw.json. 
+                        Otherwise, a default filename with the date range will be used.
 ```
 
 ## 3. Providing credentials


### PR DESCRIPTION


Fixes #217 : prevent deletion of valid weight data when multiple measurement groups share same timestamp

The sync was failing when multiple measurement types (e.g., weight + nerve health score) were recorded at the same timestamp. The code would process weight data successfully, then process the non-whitelisted measurement group and delete the entire timestamp entry, including the previously stored weight data.