### PR TITLE
ignore nonexisting garmin_session

### DIFF
--- a/withings_sync/garmin.py
+++ b/withings_sync/garmin.py
@@ -34,9 +34,12 @@ class GarminConnect:
 
     def login(self, email=None, password=None):
         if os.path.exists(GARMIN_SESSION):
-            self.client.load(GARMIN_SESSION)
-            if hasattr(self.client, "username"):
-                return
+            try:
+                self.client.load(GARMIN_SESSION)
+                if hasattr(self.client, "username"):
+                    return
+            except FileNotFoundError:
+                pass
 
         try:
             self.client.login(email, password)


### PR DESCRIPTION
ignore nonexisting garmin_session when path exists. is a common behaviour in docker.

Since my account has MFA enabled, I need to make use of the garmin-session. Had some trouble to persist it, since I mapped the .garmin_session folder to docker.