### PR TITLE
fix: authorization url is now on loglevel warning

### DIFF
--- a/withings_sync/withings2.py
+++ b/withings_sync/withings2.py
@@ -113,8 +113,8 @@ class WithingsOAuth2:
         for key, value in params.items():
             url = url + key + "=" + value + "&"
 
-        log.info(url)
-        log.info("")
+        log.warning(url)
+        log.warning("")
 
         authentification_code = input("Token : ")
 


### PR DESCRIPTION
With --silent no withings url was shown.