### PR TITLE
Add --config-folder to credential creation in installation method 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ A tool for synchronisation of the Withings API to:
   First start to ensure the container can start successfully:
 
   ```bash
-  $ docker compose run -it --remove-orphans --entrypoint "poetry run withings-sync" withings-sync
+  $ docker compose run -it --remove-orphans --entrypoint "poetry run withings-sync --config-folder /config" withings-sync
   [+] Creating 1/1
   ✔ Network stack_default  Created                                                  0.5s
   2024-12-01 01:29:02,601 - withings - ERROR - Can\'t read config file /home/youruser/.withings_user.json


### PR DESCRIPTION
Add "--config-folder /config" option to step 5 of installation method 1.3. Otherwise the withings access token is not saved to the correct location and won't be found on subsequent runs after starting with "docker compose up -d". This is analogous to step 5 of installation method 1.2.