### PR TITLE
Bumps garth to 0.7.11 to fix garmin SSO (closes #241)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = ["Topic :: Utilities",
 
 [tool.poetry.dependencies]
 python = "^3.12"
-garth = ">=0.5.0"
+garth = ">=0.7.11"
 requests = ">=2.32.3"
 lxml = ">=5.3.0"
 python-dotenv = ">=1.0.1"


### PR DESCRIPTION
Project is not working anymore (see #241).

Garth already pinpointed the problem, and a contributor fixed it. The release 0.7.11 contains the fix.