### PR TITLE
WIthings Sync Fix with Claude - Personal Fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .idea
 *.json
 .env
+venv/

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-> [!CAUTION]
-> This Release introduces breaking changes that users need to be aware of before upgrading or using it.
-> These changes were made to enhance security and compatibility but may require modifications to your existing setup.
+> [!NOTE]
+> This is a personal fork of [jaroslawhartman/withings-sync](https://github.com/jaroslawhartman/withings-sync) with minor corrections for personal use. For the original project, please refer to the upstream repository linked above.
+
+> [!IMPORTANT]
+> **Bug fix: outdated `USER_AGENT` guard removed**
 >
-> - The container now runs without root privileges.
-> - Dependencies, virtual envs, packaging is now done by Poetry.
-> - This fork requires a recent version of Python, currently capped at >= python 3.12.
->
-> Make sure to go over the updated readme and test these new changes thoroughly for your environment.
-> Chances are quite high you will have to make changes to make this work again. 
+> An outdated `USER_AGENT` override in `garmin.py` was setting the Garmin client identifier to `GCM-iOS-5.7.2.1`, which downgraded garth's own (newer) value and caused Garmin to reject upload requests. The original workaround was for [garth issue #73](https://github.com/matin/garth/issues/73), which has since been resolved in `garth >= 0.7.1`. The override has been removed and the minimum required garth version has been bumped accordingly.
 
 # withings-sync
 
@@ -630,5 +627,6 @@ The python packages are added to the GitHub releases by a GitHub Action.
 
 ## 8. Credits / Authors
 
+* This personal fork is based on [jaroslawhartman/withings-sync](https://github.com/jaroslawhartman/withings-sync) by Jarek Hartman. All credit for the original work goes to the upstream project and its contributors.
 * Based on [withings-garmin](https://github.com/ikasamah/withings-garmin) by Masayuki Hamasaki, improved to support SSO authorization in Garmin Connect 2.
-* Based on [withings-garmin-v2](https://github.com/jaroslawhartman/withings-garmin-v2) by Jarek Hartman, improved Python 3 compatability, code-style and setuptools packaging, Kubernetes and Docker support. 
+* Based on [withings-garmin-v2](https://github.com/jaroslawhartman/withings-garmin-v2) by Jarek Hartman, improved Python 3 compatability, code-style and setuptools packaging, Kubernetes and Docker support.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,204 @@
+"""Flask web UI for withings-sync."""
+import json
+import os
+import sys
+import subprocess
+
+import requests as http_requests
+from dotenv import dotenv_values, set_key
+from flask import Flask, Response, jsonify, render_template, request, stream_with_context
+
+app = Flask(__name__)
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+ENV_FILE = os.path.join(BASE_DIR, ".env")
+WITHINGS_CONFIG_FILE = os.path.expanduser("~/.withings_user.json")
+WITHINGS_TOKEN_URL = "https://wbsapi.withings.net/v2/oauth2"
+WITHINGS_AUTH_URL = "https://account.withings.com/oauth2_user/authorize2"
+
+
+def get_withings_app_config():
+    try:
+        import importlib_resources
+        ref = importlib_resources.files("withings_sync") / "config/withings_app.json"
+        with ref.open() as f:
+            return json.load(f)
+    except Exception:
+        path = os.path.join(BASE_DIR, "withings_sync", "config", "withings_app.json")
+        with open(path) as f:
+            return json.load(f)
+
+
+WITHINGS_APP = get_withings_app_config()
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/api/status")
+def status():
+    env = dotenv_values(ENV_FILE) if os.path.exists(ENV_FILE) else {}
+    garmin_configured = bool(env.get("GARMIN_USERNAME") and env.get("GARMIN_PASSWORD"))
+    withings_authed = os.path.exists(WITHINGS_CONFIG_FILE)
+
+    last_sync = None
+    if withings_authed:
+        try:
+            with open(WITHINGS_CONFIG_FILE) as f:
+                data = json.load(f)
+            last_sync = data.get("last_sync")
+        except Exception:
+            pass
+
+    return jsonify(
+        {
+            "garmin_configured": garmin_configured,
+            "garmin_username": env.get("GARMIN_USERNAME", ""),
+            "withings_authed": withings_authed,
+            "last_sync": last_sync,
+        }
+    )
+
+
+@app.route("/api/credentials", methods=["POST"])
+def save_credentials():
+    data = request.json
+    username = (data.get("username") or "").strip()
+    password = (data.get("password") or "").strip()
+
+    if not username or not password:
+        return jsonify({"success": False, "error": "Username and password are required"}), 400
+
+    if not os.path.exists(ENV_FILE):
+        open(ENV_FILE, "w").close()
+
+    set_key(ENV_FILE, "GARMIN_USERNAME", username)
+    set_key(ENV_FILE, "GARMIN_PASSWORD", password)
+    return jsonify({"success": True})
+
+
+@app.route("/api/withings/auth-url")
+def withings_auth_url():
+    url = (
+        WITHINGS_AUTH_URL
+        + "?response_type=code"
+        + "&client_id=" + WITHINGS_APP["client_id"]
+        + "&state=OK"
+        + "&scope=user.metrics"
+        + "&redirect_uri=" + WITHINGS_APP["callback_url"]
+    )
+    return jsonify({"url": url})
+
+
+@app.route("/api/withings/exchange", methods=["POST"])
+def withings_exchange():
+    auth_code = (request.json.get("code") or "").strip()
+    if not auth_code:
+        return jsonify({"success": False, "error": "Authorization code is required"}), 400
+
+    try:
+        params = {
+            "action": "requesttoken",
+            "grant_type": "authorization_code",
+            "client_id": WITHINGS_APP["client_id"],
+            "client_secret": WITHINGS_APP["consumer_secret"],
+            "code": auth_code,
+            "redirect_uri": WITHINGS_APP["callback_url"],
+        }
+        resp = http_requests.post(WITHINGS_TOKEN_URL, data=params, timeout=15)
+        data = resp.json()
+
+        if data.get("status") == 0:
+            body = data["body"]
+            config = {
+                "authentification_code": auth_code,
+                "access_token": body["access_token"],
+                "refresh_token": body["refresh_token"],
+                "userid": str(body["userid"]),
+            }
+            with open(WITHINGS_CONFIG_FILE, "w") as f:
+                json.dump(config, f, indent=4)
+            return jsonify({"success": True})
+        else:
+            error = data.get("error") or f"Withings API error (status {data.get('status')})"
+            return jsonify({"success": False, "error": error}), 400
+
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@app.route("/api/withings/disconnect", methods=["POST"])
+def withings_disconnect():
+    if os.path.exists(WITHINGS_CONFIG_FILE):
+        os.remove(WITHINGS_CONFIG_FILE)
+    return jsonify({"success": True})
+
+
+@app.route("/api/sync/stream")
+def sync_stream():
+    env = dotenv_values(ENV_FILE) if os.path.exists(ENV_FILE) else {}
+    username = (env.get("GARMIN_USERNAME") or "").strip()
+    password = (env.get("GARMIN_PASSWORD") or "").strip()
+    from_date = request.args.get("fromdate", "")
+    to_date = request.args.get("todate", "")
+
+    def generate():
+        if not username or not password:
+            yield _event("error", "Garmin credentials not configured")
+            return
+
+        if not os.path.exists(WITHINGS_CONFIG_FILE):
+            yield _event("error", "Withings not authorized — please connect Withings first")
+            return
+
+        cmd = [
+            sys.executable, "-u", "-m", "withings_sync.sync",
+            "--garmin-username", username,
+            "--garmin-password", password,
+            "--verbose",
+        ]
+        if from_date:
+            cmd += ["--fromdate", from_date]
+        if to_date:
+            cmd += ["--todate", to_date]
+
+        try:
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                cwd=BASE_DIR,
+            )
+            for line in iter(process.stdout.readline, ""):
+                msg = line.rstrip()
+                if msg:
+                    yield _event("log", msg)
+
+            process.wait()
+            if process.returncode == 0:
+                yield _event("done", "Sync completed successfully", success=True)
+            else:
+                yield _event("done", f"Sync failed (exit code {process.returncode})", success=False)
+
+        except Exception as e:
+            yield _event("error", str(e))
+
+    return Response(
+        stream_with_context(generate()),
+        mimetype="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+def _event(event_type, message, **extra):
+    payload = {"type": event_type, "message": message, **extra}
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+if __name__ == "__main__":
+    print("Starting Withings → Garmin Sync UI at http://localhost:5000")
+    app.run(host="0.0.0.0", port=5000, threaded=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = ["Topic :: Utilities",
 
 [tool.poetry.dependencies]
 python = "^3.12"
-garth = ">=0.5.0"
+garth = ">=0.7.1"
 requests = ">=2.32.3"
 lxml = ">=5.3.0"
 python-dotenv = ">=1.0.1"

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Withings → Garmin Sync</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen font-sans">
+
+  <div class="max-w-xl mx-auto py-10 px-4 space-y-5">
+
+    <!-- Header -->
+    <div class="text-center pb-2">
+      <h1 class="text-2xl font-bold text-gray-900">Withings → Garmin Sync</h1>
+      <p class="text-sm text-gray-500 mt-1">Sync your Withings weight data to Garmin Connect</p>
+    </div>
+
+    <!-- Status row -->
+    <div class="grid grid-cols-2 gap-4">
+      <div class="bg-white rounded-xl border shadow-sm p-4">
+        <div class="flex items-center gap-2 mb-0.5">
+          <span id="garmin-dot" class="w-2.5 h-2.5 rounded-full bg-gray-300 flex-shrink-0"></span>
+          <span class="font-semibold text-sm text-gray-700">Garmin Connect</span>
+        </div>
+        <p id="garmin-status" class="text-xs text-gray-400 pl-4">Not configured</p>
+      </div>
+      <div class="bg-white rounded-xl border shadow-sm p-4">
+        <div class="flex items-center gap-2 mb-0.5">
+          <span id="withings-dot" class="w-2.5 h-2.5 rounded-full bg-gray-300 flex-shrink-0"></span>
+          <span class="font-semibold text-sm text-gray-700">Withings</span>
+        </div>
+        <p id="withings-status" class="text-xs text-gray-400 pl-4">Not authorized</p>
+      </div>
+    </div>
+
+    <!-- Garmin Credentials -->
+    <div class="bg-white rounded-xl border shadow-sm p-6">
+      <h2 class="text-base font-semibold text-gray-800 mb-4">Garmin Credentials</h2>
+      <div class="space-y-3">
+        <div>
+          <label class="block text-xs font-medium text-gray-600 mb-1">Email / Username</label>
+          <input id="garmin-username" type="email" autocomplete="off"
+            class="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="your@email.com" />
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-gray-600 mb-1">Password</label>
+          <input id="garmin-password" type="password" autocomplete="new-password"
+            class="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="••••••••" />
+        </div>
+        <button onclick="saveCredentials()"
+          class="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 active:bg-blue-800 transition-colors">
+          Save Credentials
+        </button>
+        <p id="credentials-msg" class="text-xs text-center hidden"></p>
+      </div>
+    </div>
+
+    <!-- Withings Authorization -->
+    <div class="bg-white rounded-xl border shadow-sm p-6">
+      <h2 class="text-base font-semibold text-gray-800 mb-4">Withings Authorization</h2>
+
+      <!-- Connected state -->
+      <div id="withings-connected" class="hidden">
+        <div class="flex items-center justify-between bg-green-50 border border-green-200 rounded-lg px-4 py-3">
+          <span class="text-sm text-green-700 font-medium">Connected to Withings</span>
+          <button onclick="disconnectWithings()"
+            class="text-xs text-red-500 hover:text-red-700 font-medium transition-colors">
+            Disconnect
+          </button>
+        </div>
+      </div>
+
+      <!-- Not connected state -->
+      <div id="withings-not-connected">
+        <p class="text-sm text-gray-500 mb-4">
+          Click below to open the Withings authorization page. After you approve access, you'll see a page with a
+          short code — copy it and paste it here.
+        </p>
+        <button onclick="openWithingsAuth()"
+          class="w-full bg-orange-500 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-orange-600 active:bg-orange-700 transition-colors mb-4">
+          Authorize with Withings
+        </button>
+
+        <div id="token-section" class="hidden space-y-2">
+          <label class="block text-xs font-medium text-gray-600">Paste the code from the Withings page</label>
+          <div class="flex gap-2">
+            <input id="withings-token" type="text"
+              class="flex-1 border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-400"
+              placeholder="e.g. 2b1ac3a3f6c3ade5..." />
+            <button onclick="exchangeToken()"
+              class="bg-orange-500 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-orange-600 transition-colors">
+              Connect
+            </button>
+          </div>
+          <p id="withings-msg" class="text-xs hidden"></p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Sync -->
+    <div class="bg-white rounded-xl border shadow-sm p-6">
+      <h2 class="text-base font-semibold text-gray-800 mb-4">Sync</h2>
+
+      <div class="grid grid-cols-2 gap-3 mb-4">
+        <div>
+          <label class="block text-xs font-medium text-gray-600 mb-1">From date <span class="text-gray-400">(optional)</span></label>
+          <input id="from-date" type="date"
+            class="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500" />
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-gray-600 mb-1">To date <span class="text-gray-400">(optional)</span></label>
+          <input id="to-date" type="date"
+            class="w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500" />
+        </div>
+      </div>
+
+      <button id="sync-btn" onclick="startSync()"
+        class="w-full bg-green-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-green-700 active:bg-green-800 transition-colors">
+        Sync Now
+      </button>
+
+      <p id="last-sync" class="text-xs text-gray-400 text-center mt-3 hidden"></p>
+
+      <!-- Log output -->
+      <div id="sync-log"
+        class="hidden mt-4 bg-gray-900 rounded-lg p-4 font-mono text-xs overflow-y-auto max-h-72 space-y-0.5">
+      </div>
+    </div>
+
+  </div><!-- end container -->
+
+  <script>
+    let syncSource = null;
+
+    async function loadStatus() {
+      const resp = await fetch('/api/status');
+      const d = await resp.json();
+
+      // Garmin
+      const gDot = document.getElementById('garmin-dot');
+      const gStatus = document.getElementById('garmin-status');
+      if (d.garmin_configured) {
+        gDot.className = 'w-2.5 h-2.5 rounded-full bg-green-500 flex-shrink-0';
+        gStatus.textContent = d.garmin_username;
+        document.getElementById('garmin-username').value = d.garmin_username;
+      } else {
+        gDot.className = 'w-2.5 h-2.5 rounded-full bg-red-400 flex-shrink-0';
+        gStatus.textContent = 'Not configured';
+      }
+
+      // Withings
+      const wDot = document.getElementById('withings-dot');
+      const wStatus = document.getElementById('withings-status');
+      if (d.withings_authed) {
+        wDot.className = 'w-2.5 h-2.5 rounded-full bg-green-500 flex-shrink-0';
+        wStatus.textContent = 'Connected';
+        document.getElementById('withings-connected').classList.remove('hidden');
+        document.getElementById('withings-not-connected').classList.add('hidden');
+      } else {
+        wDot.className = 'w-2.5 h-2.5 rounded-full bg-red-400 flex-shrink-0';
+        wStatus.textContent = 'Not authorized';
+        document.getElementById('withings-connected').classList.add('hidden');
+        document.getElementById('withings-not-connected').classList.remove('hidden');
+      }
+
+      // Last sync
+      const lastEl = document.getElementById('last-sync');
+      if (d.last_sync) {
+        lastEl.textContent = 'Last sync: ' + new Date(d.last_sync * 1000).toLocaleString();
+        lastEl.classList.remove('hidden');
+      } else {
+        lastEl.classList.add('hidden');
+      }
+    }
+
+    async function saveCredentials() {
+      const username = document.getElementById('garmin-username').value.trim();
+      const password = document.getElementById('garmin-password').value.trim();
+      const msg = document.getElementById('credentials-msg');
+
+      if (!username || !password) {
+        showMsg(msg, 'Please enter both username and password.', false);
+        return;
+      }
+
+      const resp = await fetch('/api/credentials', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      const d = await resp.json();
+      if (d.success) {
+        showMsg(msg, 'Credentials saved.', true);
+        loadStatus();
+      } else {
+        showMsg(msg, d.error || 'Failed to save credentials.', false);
+      }
+    }
+
+    async function openWithingsAuth() {
+      const resp = await fetch('/api/withings/auth-url');
+      const d = await resp.json();
+      window.open(d.url, '_blank');
+      document.getElementById('token-section').classList.remove('hidden');
+      document.getElementById('withings-token').focus();
+    }
+
+    async function exchangeToken() {
+      const code = document.getElementById('withings-token').value.trim();
+      const msg = document.getElementById('withings-msg');
+
+      if (!code) {
+        showMsg(msg, 'Please paste the authorization code.', false);
+        return;
+      }
+
+      const resp = await fetch('/api/withings/exchange', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+      const d = await resp.json();
+      if (d.success) {
+        showMsg(msg, 'Withings connected successfully!', true);
+        setTimeout(loadStatus, 500);
+      } else {
+        showMsg(msg, d.error || 'Failed to connect to Withings.', false);
+      }
+    }
+
+    async function disconnectWithings() {
+      if (!confirm('Disconnect from Withings? You will need to re-authorize to sync again.')) return;
+      await fetch('/api/withings/disconnect', { method: 'POST' });
+      loadStatus();
+    }
+
+    function startSync() {
+      const fromDate = document.getElementById('from-date').value;
+      const toDate = document.getElementById('to-date').value;
+      const log = document.getElementById('sync-log');
+      const btn = document.getElementById('sync-btn');
+
+      log.classList.remove('hidden');
+      log.innerHTML = '';
+      btn.disabled = true;
+      btn.textContent = 'Syncing…';
+      btn.className = btn.className.replace('bg-green-600 hover:bg-green-700 active:bg-green-800', 'bg-gray-400 cursor-not-allowed');
+
+      let url = '/api/sync/stream';
+      const params = [];
+      if (fromDate) params.push('fromdate=' + fromDate);
+      if (toDate) params.push('todate=' + toDate);
+      if (params.length) url += '?' + params.join('&');
+
+      if (syncSource) syncSource.close();
+      syncSource = new EventSource(url);
+
+      syncSource.onmessage = (e) => {
+        const msg = JSON.parse(e.data);
+
+        if (msg.type === 'done' || msg.type === 'error') {
+          syncSource.close();
+          btn.disabled = false;
+          btn.textContent = 'Sync Now';
+          btn.className = btn.className.replace('bg-gray-400 cursor-not-allowed', 'bg-green-600 hover:bg-green-700 active:bg-green-800');
+
+          if (msg.type === 'done') {
+            const ok = msg.success;
+            appendLog(log, ok ? '✓ ' + msg.message : '✗ ' + msg.message, ok ? 'text-green-400' : 'text-red-400');
+            if (ok) loadStatus();
+          } else {
+            appendLog(log, '✗ ' + msg.message, 'text-red-400');
+          }
+          return;
+        }
+
+        if (msg.type === 'log') {
+          let color = 'text-gray-300';
+          if (msg.message.includes('ERROR')) color = 'text-red-400';
+          else if (msg.message.includes('WARNING')) color = 'text-yellow-300';
+          else if (msg.message.includes('INFO')) color = 'text-blue-300';
+          appendLog(log, msg.message, color);
+        }
+      };
+
+      syncSource.onerror = () => {
+        syncSource.close();
+        btn.disabled = false;
+        btn.textContent = 'Sync Now';
+        btn.className = btn.className.replace('bg-gray-400 cursor-not-allowed', 'bg-green-600 hover:bg-green-700 active:bg-green-800');
+        appendLog(log, 'Connection lost.', 'text-red-400');
+      };
+    }
+
+    function appendLog(container, text, colorClass) {
+      const line = document.createElement('div');
+      line.className = colorClass;
+      line.textContent = text;
+      container.appendChild(line);
+      container.scrollTop = container.scrollHeight;
+    }
+
+    function showMsg(el, text, success) {
+      el.classList.remove('hidden', 'text-green-600', 'text-red-600');
+      el.classList.add(success ? 'text-green-600' : 'text-red-600');
+      el.textContent = text;
+      setTimeout(() => el.classList.add('hidden'), 4000);
+    }
+
+    loadStatus();
+  </script>
+</body>
+</html>

--- a/withings_sync/garmin.py
+++ b/withings_sync/garmin.py
@@ -5,8 +5,6 @@ import logging
 import os
 
 import garth
-# Temporary fix until Garth project merges https://github.com/matin/garth/issues/73
-garth.http.USER_AGENT = {"User-Agent": ("GCM-iOS-5.7.2.1")}
 
 log = logging.getLogger("garmin")
 


### PR DESCRIPTION
Summary
This is a personal fork of [jaroslawhartman/withings-sync](https://github.com/jaroslawhartman/withings-sync) with two changes on top of the upstream:

Bug fix: Remove outdated garth USER_AGENT override
The garmin.py module contained a workaround that hardcoded the Garmin client User-Agent to GCM-iOS-5.7.2.1. This was originally added as a temporary fix for [garth issue #73](https://github.com/matin/garth/issues/73), but it had become counterproductive — it was overwriting garth's own (newer, correct) value and causing Garmin to reject upload requests.

The fix in garth issue #73 was shipped in garth >= 0.7.1, so the workaround has been removed and the minimum required garth version bumped from >=0.5.0 to >=0.7.1.

Files changed: withings_sync/garmin.py, pyproject.toml

Flask web UI
Added a lightweight browser-based interface (app.py + templates/index.html) for running syncs without the command line. It allows configuring Garmin credentials, authorising Withings via OAuth2, and running a sync with live streaming log output — all from a browser.

Files added: app.py, templates/index.html

Feel free to adjust the tone or trim the Flask UI section if you're only raising the bug fix PR upstream.

Let me check the current state of the repo first.