### PR TITLE
fix: track TrainerRoad sync timestamp independently of Garmin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.11-alpine
 
 ARG PROJECT="withings-sync"
 ARG PACKAGE="withings_sync"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = ["Topic :: Utilities",
               ]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 garminconnect = ">=0.3.2"
 requests = ">=2.32.3"
 lxml = ">=5.3.0"

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -514,7 +514,14 @@ def sync():
     withings = WithingsAccount(config_folder=config_folder)
 
     if not ARGS.fromdate:
-        startdate = withings.get_lastsync()
+        if ARGS.trainerroad_username and ARGS.garmin_username:
+            startdate = min(withings.get_lastsync(), withings.get_lastsync_tr())
+        elif ARGS.garmin_username:
+            startdate = withings.get_lastsync()
+        elif ARGS.trainerroad_username:
+            startdate = withings.get_lastsync_tr()
+        else:
+            startdate = withings.get_lastsync()
     else:
         startdate = int(time.mktime(ARGS.fromdate.timetuple()))
 
@@ -567,6 +574,8 @@ def sync():
             logging.info(" Measured %s", last_date_time)
             if sync_trainerroad(last_weight):
                 logging.info("TrainerRoad update done!")
+                if not ARGS.fromdate:
+                    withings.set_lastsync_tr()
         else:
             logging.info("No TrainerRoad username or a new measurement - skipping sync")
 

--- a/withings_sync/sync.py
+++ b/withings_sync/sync.py
@@ -636,8 +636,8 @@ def main():
     logging.debug("withings-sync script version %s", version("withings-sync"))
     logging.debug("Script invoked with the following arguments: %s", ARGS)
 
-    if sys.version_info < (3, 12):
-        print("Sorry, requires at least Python3.12.")
+    if sys.version_info < (3, 11):
+        print("Sorry, requires at least Python3.11.")
         sys.exit(1)
 
     sync()

--- a/withings_sync/withings2.py
+++ b/withings_sync/withings2.py
@@ -17,7 +17,7 @@ GETMEAS_URL = "https://wbsapi.withings.net/measure?action=getmeas"
 
 APP_CONFIG = os.environ.get(
     "WITHINGS_APP",
-    importlib.resources.files(__name__) / "config/withings_app.json",
+    importlib.resources.files(__package__) / "config/withings_app.json",
 )
 USER_CONFIG = os.environ.get("WITHINGS_USER", HOME + "/.withings_user.json")
 

--- a/withings_sync/withings2.py
+++ b/withings_sync/withings2.py
@@ -235,6 +235,18 @@ class WithingsAccount:
         log.info("Saving Last Sync")
         self.withings.update_config()
 
+    def get_lastsync_tr(self):
+        """get last TrainerRoad sync timestamp"""
+        if not self.withings.user_config.get("last_sync_tr"):
+            return int(time.mktime(date.today().timetuple()))
+        return self.withings.user_config["last_sync_tr"]
+
+    def set_lastsync_tr(self):
+        """set last TrainerRoad sync timestamp"""
+        self.withings.user_config["last_sync_tr"] = int(time.time())
+        log.info("Saving Last TR Sync")
+        self.withings.update_config()
+
     def get_measurements(self, startdate, enddate):
         """get Withings measurements"""
         log.info("Get Measurements")

--- a/withings_sync/withings2.py
+++ b/withings_sync/withings2.py
@@ -4,7 +4,7 @@ import logging
 import json
 import os
 import time
-import importlib_resources
+import importlib.resources
 import requests
 
 log = logging.getLogger("withings")
@@ -17,7 +17,7 @@ GETMEAS_URL = "https://wbsapi.withings.net/measure?action=getmeas"
 
 APP_CONFIG = os.environ.get(
     "WITHINGS_APP",
-    importlib_resources.files(__name__) / "config/withings_app.json",
+    importlib.resources.files(__name__) / "config/withings_app.json",
 )
 USER_CONFIG = os.environ.get("WITHINGS_USER", HOME + "/.withings_user.json")
 


### PR DESCRIPTION
Merges @sl16de's [fix/lastsync-trainerroad](https://github.com/sl16de/withings-sync/tree/fix/lastsync-trainerroad) branch into master with conflicts resolved.

## Changes from the PR

- **f5c196c** fix: track TrainerRoad sync timestamp independently of Garmin
  - Adds `last_sync_tr` to the Withings user config so the fetch window is correctly maintained for TR-only setups. Previously `set_lastsync()` was only called after a successful Garmin upload, causing TR-only setups to lose measurements on days the cron job failed.
  - `startdate` now uses `last_sync_tr` (TR only), `last_sync` (Garmin only), or `min(last_sync, last_sync_tr)` when both are configured.
- **e2ded02** chore: lower Python requirement to 3.11 and drop importlib-resources backport
- **3ffcd58** fix: use `__package__` instead of `__name__` for `importlib.resources.files()`

## Conflict resolution

- `pyproject.toml`: kept master's `garminconnect` migration AND the PR's `python = "^3.11"` lower bound.
- `withings_sync/sync.py`: auto-merged — kept both master's new single-instance Garmin auth + `config_folder` support AND the PR's conditional `startdate` logic with `get_lastsync_tr`/`set_lastsync_tr`.
- `poetry.lock`: regenerated to match the resolved `pyproject.toml` (verified with `poetry check --lock`).

Closes sl16de's PR by merging his work directly.