### PR TITLE
fix: send consistent browser-like headers for TrainerRoad login

### DIFF
--- a/withings_sync/trainerroad.py
+++ b/withings_sync/trainerroad.py
@@ -4,6 +4,18 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# TrainerRoad's WAF blocks requests carrying the default python-requests
+# User-Agent (returns 429 regardless of credentials). Set once on the
+# session so every request in a connect()...disconnect() cycle looks
+# consistently browser-like, rather than only patching individual calls.
+_BROWSER_HEADERS = {
+    'User-Agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+                    'AppleWebKit/537.36 (KHTML, like Gecko) '
+                    'Chrome/140.0.0.0 Safari/537.36'),
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'en-US,en;q=0.9',
+}
+
 
 class TrainerRoad:
     _ftp = 'ftp'
@@ -24,16 +36,19 @@ class TrainerRoad:
 
     def connect(self):
         self._session = requests.Session()
-        
+        self._session.headers.update(_BROWSER_HEADERS)
+
         data = {'Username': self._username,
                 'Password': self._password}
 
         r = self._session.post(self._login_url, data=data,
+                               headers={'Origin': 'https://www.trainerroad.com',
+                                        'Referer': self._login_url},
                                allow_redirects=False)
 
         if r.status_code not in [200, 302]:
-            raise RuntimeError("Error loging in to TrainerRoad (Code {})"
-                               .format(r.status_code))
+            raise RuntimeError("Error loging in to TrainerRoad (Code {}, Retry-After {})"
+                               .format(r.status_code, r.headers.get('Retry-After')))
 
         logger.info('Logged into TrainerRoad as "{}"'.format(self._username))
 
@@ -59,12 +74,12 @@ class TrainerRoad:
         if self._session is None:
             raise RuntimeError('Not Connected')
 
-        # Add browser-like headers for API calls (camelCase JSON format)
+        # Endpoint-specific headers; browser UA/Accept-Language already set
+        # on the session by connect().
         headers = {
             'Accept': 'application/json, text/plain, */*',
             'Referer': 'https://www.trainerroad.com/app/profile/rider-information',
             'trainerroad-jsonformat': 'camel-case',
-            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0'
         }
 
         r = self._session.get(url, headers=headers)
@@ -120,14 +135,14 @@ class TrainerRoad:
         logger.info("Updating profile: Weight={}, FTP={}".format(
             data.get(self._weight), data.get(self._ftp)))
 
-        # Send PUT request with JSON data (exact browser headers)
+        # Endpoint-specific headers; browser UA/Accept-Language already set
+        # on the session by connect().
         headers = {
             'Accept': 'application/json, text/plain, */*',
             'Content-Type': 'application/json',
             'Origin': 'https://www.trainerroad.com',
             'Referer': 'https://www.trainerroad.com/app/profile/rider-information',
             'trainerroad-jsonformat': 'camel-case',
-            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0'
         }
         r = self._session.put(self._profile_api_url, json=data, headers=headers)
 


### PR DESCRIPTION
## Problem

TrainerRoad's WAF (Azure Application Gateway) started rejecting login requests carrying the default `python-requests` User-Agent with HTTP 429 around 2026-07-26, regardless of credential validity. This breaks `sync_trainerroad()` for every user, since `connect()` never set any headers on the session.

Verified independently via `curl`: an identical `POST /app/login` succeeds (200/302) with a browser-like `User-Agent`, but 429s immediately with `python-requests/...` — even with throwaway/invalid credentials, confirming it's a UA-based block, not a credentials or rate-limit issue.

Related: #254

## Fix

`connect()` now sets browser-like headers (`User-Agent`, `Accept`, `Accept-Language`) once on the `requests.Session`, instead of only patching the login `POST`. Since `_get()` and `_write_profile()` already carried their own hand-rolled browser headers (added in #213), this also removes the duplication and the inconsistency between them (they used a different UA than what #254's proposed patch would have added to `connect()`) — every request sharing the session (login, logout, profile read/write, workouts, download) now sends the same, consistent browser fingerprint, which is closer to how a real browser behaves and less likely to trip other bot-detection heuristics down the line.

Also surfaces `Retry-After` in the error message on login failure, for easier diagnosis if TrainerRoad rate-limits legitimately in the future.

## Test plan

- [x] Reproduced the 429 against the live TrainerRoad login endpoint before the fix
- [x] Deployed this branch to a production cron-triggered instance (Raspberry Pi, Python 3.11) and ran a full sync: login → profile read → profile update (Weight/FTP) → logout all succeeded
- [x] `sync.py`/`withings2.py` untouched — this PR only touches `trainerroad.py`